### PR TITLE
bug: BooleanOptionalAction not available for python 3.8

### DIFF
--- a/.github/workflows/bin/determine.py
+++ b/.github/workflows/bin/determine.py
@@ -58,8 +58,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='determine what changed')
     parser.add_argument('changed_files', type=str,
                         help='space-separated list of changed files')
-    parser.add_argument('--epoch', action=argparse.BooleanOptionalAction)
-    parser.add_argument('--distro', action=argparse.BooleanOptionalAction)
+    parser.add_argument('--epoch', action='store_true')
+    parser.add_argument('--distro', action='store_true')
 
     args = parser.parse_args()
     changed_files = args.changed_files.split(' ')


### PR DESCRIPTION
This modifies the actions for the --epoch and --distro flags. BooleanOptionalAction is only available for Python 3.9+ so this needed to be modified with a workaround for python 3.8