### PR TITLE
IMP: adds jupyter notebook to the meta.yaml.jinja file

### DIFF
--- a/2022.11/staged/community/meta.yaml.jinja
+++ b/2022.11/staged/community/meta.yaml.jinja
@@ -8,6 +8,7 @@ requirements:
 add any dependency-specific override pins here
     - foo 1.2.3
 #}
+    - notebook
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:

--- a/2022.11/staged/core/meta.yaml.jinja
+++ b/2022.11/staged/core/meta.yaml.jinja
@@ -8,7 +8,7 @@ requirements:
 add any dependency-specific override pins here
     - foo 1.2.3
 #}
-    - notebook ==6.5.1
+    - notebook 6.5.1
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:

--- a/2022.11/staged/core/meta.yaml.jinja
+++ b/2022.11/staged/core/meta.yaml.jinja
@@ -8,7 +8,7 @@ requirements:
 add any dependency-specific override pins here
     - foo 1.2.3
 #}
-    - notebook 6.5.1
+    - notebook
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:

--- a/2022.11/staged/core/meta.yaml.jinja
+++ b/2022.11/staged/core/meta.yaml.jinja
@@ -7,7 +7,8 @@ requirements:
 {#- NOTE:
 add any dependency-specific override pins here
     - foo 1.2.3
-#}
+#
+   - notebook 6.5.1}
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:

--- a/2022.11/staged/core/meta.yaml.jinja
+++ b/2022.11/staged/core/meta.yaml.jinja
@@ -8,7 +8,7 @@ requirements:
 add any dependency-specific override pins here
     - foo 1.2.3
 #}
-   - notebook==6.5.1
+   - notebook ==6.5.1
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:

--- a/2022.11/staged/core/meta.yaml.jinja
+++ b/2022.11/staged/core/meta.yaml.jinja
@@ -7,8 +7,8 @@ requirements:
 {#- NOTE:
 add any dependency-specific override pins here
     - foo 1.2.3
-#
-   - notebook 6.5.1}
+#}
+   - notebook 6.5.1
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:

--- a/2022.11/staged/core/meta.yaml.jinja
+++ b/2022.11/staged/core/meta.yaml.jinja
@@ -8,7 +8,7 @@ requirements:
 add any dependency-specific override pins here
     - foo 1.2.3
 #}
-   - notebook ==6.5.1
+    - notebook ==6.5.1
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:

--- a/2022.11/staged/core/meta.yaml.jinja
+++ b/2022.11/staged/core/meta.yaml.jinja
@@ -8,7 +8,7 @@ requirements:
 add any dependency-specific override pins here
     - foo 1.2.3
 #}
-   - notebook 6.5.1
+   - notebook==6.5.1
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:


### PR DESCRIPTION
This PR adds notebook to the Meta.yaml.jinja file so that notebook is always installed with qiime2.