### PR TITLE
imp: adds jupyter notebook to core distro install

### DIFF
--- a/2022.11/staged/core/meta.yaml.jinja
+++ b/2022.11/staged/core/meta.yaml.jinja
@@ -8,6 +8,7 @@ requirements:
 add any dependency-specific override pins here
     - foo 1.2.3
 #}
+    - notebook
 {#- NOTE:
 add the following list to data.yaml as an escape hatch to force exclusion of
 a package, if necessary:


### PR DESCRIPTION
This PR was split off from @cherman2's closed PR [here](https://github.com/qiime2/package-integration/pull/346). This adds the jupyter notebook extension to all core distro installations for QIIME 2 2022.11 and later.