### PR TITLE
TST: try using mambabuild instead

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -19,7 +19,7 @@ runs:
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate base
         wget ${{ inputs.pkg-url }}
-        sudo conda build -q \
+        sudo conda mambabuild -q \
           -c ${{ inputs.q2-channel }} \
           -c conda-forge \
           -c bioconda \


### PR DESCRIPTION
This is to see if we can avoid the persistent issues with resolution where conda's solver for testing seems to decide there's a mismatched MPI feature.