### PR TITLE
TST: new test running script

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -16,13 +16,13 @@ runs:
     - name: run test
       shell: bash
       run: |
-        source "$CONDA/etc/profile.d/conda.sh"
-        conda activate base
         wget ${{ inputs.pkg-url }}
-        sudo conda build -q \
+        source "$CONDA/etc/profile.d/conda.sh"
+        conda create -n test-env -y -q
           -c ${{ inputs.q2-channel }} \
           -c conda-forge \
           -c bioconda \
           -c defaults \
-          --extra-deps ${{ inputs.metapackage-spec }} \
-          -t "*.tar.bz2"
+          ${{ inputs.metapackage-spec }}
+        conda activate test-env
+        ${{ github.action_path }}/.github/actions/test-package/bin/run_tests.py *.tar.bz2

--- a/.github/actions/test-package/bin/run_tests.py
+++ b/.github/actions/test-package/bin/run_tests.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import sys
+import yaml
+import tarfile
+import importlib
+import subprocess
+
+
+def find_tests(conda_pkg):
+    with tarfile.open(conda_pkg, mode='r:bz2') as fh:
+        recipe_fh = fh.extractfile('info/recipe/meta.yaml')
+        tests = yaml.safe_load(recipe_fh).get('test')
+    return tests
+
+
+def run_imports(imports):
+    for imp in imports:
+        print(f'Importing: {imp}')
+        importlib.import_module(imp)
+
+
+def run_commands(commands):
+    for cmd in commands:
+        print(f'Running: {cmd}')
+        subprocess.run(cmd, shell=True, check=True)
+
+
+def main(conda_pkg):
+    tests = find_tests(conda_pkg)
+    run_imports(tests['imports'])
+    run_commands(tests['commands'])
+
+
+if __name__ == '__main__':
+    conda_pkg = sys.argv[1]
+    main(conda_pkg)


### PR DESCRIPTION
This adds a new script which is independent of `conda` to run the tests defined in a recipe within a given environment.

This is an attempt to get around the issue's we're seeing with the conda solver picking a different route and ending up with mismatched features when using `conda build -t --extra-deps <arg>`.

The main downside is that we don't install any of the test dependencies, which may become a problem eventually, but what we really want to test is the current environment. So if this starts to matter, we may need to rethink other things as well.