### PR TITLE
oops: updating github action path

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -25,4 +25,4 @@ runs:
           -c defaults \
           ${{ inputs.metapackage-spec }}
         conda activate test-env
-        ${{ github.action_path }}/.github/actions/test-package/bin/run_tests.py *.tar.bz2
+        ${{ github.action_path }}/bin/run_tests.py *.tar.bz2


### PR DESCRIPTION
Looks like github already includes .github/actions/test-package in the path, so that's not needed manually.