### PR TITLE
bug: macos doesn't have write access by default

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -18,11 +18,11 @@ runs:
       run: |
         wget ${{ inputs.pkg-url }}
         source "$CONDA/etc/profile.d/conda.sh"
-        conda create -n test-env -y -q \
+        conda activate base
+        sudo conda install -n base -y -q \
           -c ${{ inputs.q2-channel }} \
           -c conda-forge \
           -c bioconda \
           -c defaults \
           ${{ inputs.metapackage-spec }}
-        conda activate test-env
-        ${{ github.action_path }}/bin/run_tests.py *.tar.bz2
+        sudo ${{ github.action_path }}/bin/run_tests.py *.tar.bz2


### PR DESCRIPTION
This PR attempts to fix build failures for macOS due to default access not containing write permissions.