### PR TITLE
imp: adds q2-channel to conda install cmds

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -25,4 +25,4 @@ runs:
           -c defaults \
           ${{ inputs.metapackage-spec }}
         conda activate test-env
-        ${{ github.action_path }}/bin/run_tests.py *.tar.bz2
+        ${{ github.action_path }}/bin/run_tests.py *.tar.bz2 ${{ inputs.q2-channel }}

--- a/.github/actions/test-package/bin/run_tests.py
+++ b/.github/actions/test-package/bin/run_tests.py
@@ -15,8 +15,8 @@ def find_tests(conda_pkg):
 
 def install_requires(reqs):
     print(f'Installing: {" ".join(reqs)}', flush=True)
-    subprocess.run(['conda', 'install', '-c', 'conda-forge', '-c', 'bioconda',
-                    '-y', '-q', *reqs], check=True)
+    subprocess.run(['conda', 'install', '-c', sys.argv[2], '-c', 'conda-forge',
+                    '-c', 'bioconda', '-y', '-q', *reqs], check=True)
 
 
 def run_imports(imports):


### PR DESCRIPTION
this PR adds the q2-channel input as a conda channel when running conda install within the test-package action.