### PR TITLE
imp: branch for osx permissions in conda config action

### DIFF
--- a/.github/actions/configure-conda/action.yml
+++ b/.github/actions/configure-conda/action.yml
@@ -6,7 +6,10 @@ runs:
     - name: configure conda and friends
       shell: bash
       run: |
-        sudo chown -R 501:20 /usr/local/miniconda
+        if [ "$RUNNER_OS" == "macOS"]; then
+          echo "Running on macOS"
+          sudo chown -R 501:20 /usr/local/miniconda
+        fi
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate base
         conda config --set always_yes yes
@@ -23,6 +26,5 @@ runs:
           conda-build \
           conda-verify \
           yq
-        sudo chown -R 501:20 /usr/local/miniconda
         conda info -a
         conda config --show

--- a/.github/actions/configure-conda/action.yml
+++ b/.github/actions/configure-conda/action.yml
@@ -7,7 +7,6 @@ runs:
       shell: bash
       run: |
         if [ "$RUNNER_OS" == "macOS"]; then
-          echo "Running on macOS"
           sudo chown -R 501:20 /usr/local/miniconda
         fi
         source "$CONDA/etc/profile.d/conda.sh"


### PR DESCRIPTION
this PR creates a branch in our configure-conda action that will update osx permissions, but will leave permissions unchanged for any other OS.