### PR TITLE
debug: adding chown as first step in conda config

### DIFF
--- a/.github/actions/configure-conda/action.yml
+++ b/.github/actions/configure-conda/action.yml
@@ -6,6 +6,9 @@ runs:
     - name: configure conda and friends
       shell: bash
       run: |
+        if [ "$RUNNER_OS" == "macOS"]; then
+          sudo chown -R 501:20 /usr/local/miniconda
+        fi
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate base
         conda config --set always_yes yes


### PR DESCRIPTION
adding this as the first step (in addition to at the end) to allow for read permissions for files within usr/local/miniconda