### PR TITLE
pin: r-base 4.2.0

### DIFF
--- a/2022.11/staged/community/conda_build_config.yaml
+++ b/2022.11/staged/community/conda_build_config.yaml
@@ -74,6 +74,8 @@ qiime2:
 - 2022.11.0.dev0+15.ga0071b5
 qiime2_epoch:
 - '2022.11'
+r-base:
+- '>=4.2.0'
 rescript:
 - 2021.11.0+9.gadb941c
 scikit_bio:

--- a/2022.11/staged/core/conda_build_config.yaml
+++ b/2022.11/staged/core/conda_build_config.yaml
@@ -62,6 +62,8 @@ qiime2:
 - 2022.11.0.dev0+15.ga0071b5
 qiime2_epoch:
 - '2022.11'
+r-base:
+- '>=4.2.0'
 scikit_bio:
 - 0.5.7
 scikit_learn:

--- a/2022.11/tested/conda_build_config.yaml
+++ b/2022.11/tested/conda_build_config.yaml
@@ -76,6 +76,8 @@ qiime2:
 - 2022.11.0.dev0+16.g77df12a
 qiime2_epoch:
 - '2022.11'
+r-base:
+- '>=4.2.0'
 rescript:
 - 2021.11.0+9.gadb941c
 scikit_bio:


### PR DESCRIPTION
this PR sets a min pin for r-base at 4.2.0, which will bring us up to date with the latest bioconductor-dada2 release and will allow for compatibility of bioconductor-ancombc within q2-composition, which requires r-base 4.2.0.