### PR TITLE
REVERT: Revert the pin back to the newer version

### DIFF
--- a/2022.11/staged/core/conda_build_config.yaml
+++ b/2022.11/staged/core/conda_build_config.yaml
@@ -63,7 +63,7 @@ qiime2:
 qiime2_epoch:
 - '2022.11'
 r_base:
-- 4.1.3
+- '>=4.2.0'
 scikit_bio:
 - 0.5.7
 scikit_learn:

--- a/2022.11/tested/conda_build_config.yaml
+++ b/2022.11/tested/conda_build_config.yaml
@@ -77,7 +77,7 @@ qiime2:
 qiime2_epoch:
 - '2022.11'
 r_base:
-- 4.1.3
+- '>=4.2.0'
 rescript:
 - 2021.11.0+9.gadb941c
 scikit_bio:


### PR DESCRIPTION
Undo the pinning of the old version of r-base because it doesn't matter