### PR TITLE
pin: unifrac & unifrac_binaries min pin

### DIFF
--- a/2022.11/tested/conda_build_config.yaml
+++ b/2022.11/tested/conda_build_config.yaml
@@ -87,6 +87,6 @@ scikit_learn:
 scipy:
 - '>=1.7'
 unifrac:
-- 1.1.1
+- '>=1.1.1'
 unifrac_binaries:
-- 1.1.1
+- '>=1.1.1'


### PR DESCRIPTION
This PR sets the current pins for unifrac & unifrac_binaries as min pins to (hopefully) resolve the package integration failures for diversity_lib