### PR TITLE
Revert "pin: skbio release & removing scipy max pin"

### DIFF
--- a/2022.11/tested/conda_build_config.yaml
+++ b/2022.11/tested/conda_build_config.yaml
@@ -81,11 +81,11 @@ r_base:
 rescript:
 - 2021.11.0+9.gadb941c
 scikit_bio:
-- 0.5.8
+- 0.5.7
 scikit_learn:
 - 0.24.1
 scipy:
-- '>=1.7'
+- '>=1.7,<1.9'
 unifrac:
 - 1.1.1
 unifrac_binaries:


### PR DESCRIPTION
Reverts qiime2/package-integration#482 due to incompatibilities with unifrac & unifrac-binaries. This will be re-reverted with a release patch once [this PR](https://github.com/bioconda/bioconda-recipes/pull/38396) has been merged.